### PR TITLE
defect (EEM-342): rename Request-ID header to X-Request-ID

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -592,7 +592,7 @@ class Client
         // Adding custom headers
         $requestHeaders = array_merge([
             'Accept' => $acceptContentType,
-            'Request-ID' => $requestID
+            'X-Request-ID' => $requestID
         ], $headers);
 
         // Add credentials
@@ -635,6 +635,6 @@ class Client
         }
 
         // Return the decoded JSON and let the caller create the appropriate result format
-        return $this->parseResponse($response, $requestHeaders['Request-ID']);
+        return $this->parseResponse($response, $requestHeaders['X-Request-ID']);
     }
 }


### PR DESCRIPTION
According to the logic implemented in the [EEM-141](https://integrate.atlassian.net/browse/EEM-141), the `X-Request-ID` header must be always passed to avoid `BadRequestHttpException` from API.